### PR TITLE
Fix caching on JSON body read

### DIFF
--- a/httpcache.go
+++ b/httpcache.go
@@ -533,7 +533,7 @@ type cachingReadCloser struct {
 func (r *cachingReadCloser) Read(p []byte) (n int, err error) {
 	n, err = r.R.Read(p)
 	r.buf.Write(p[:n])
-	if err == io.EOF {
+	if err == io.EOF || n < len(p) {
 		r.OnEOF(bytes.NewReader(r.buf.Bytes()))
 	}
 	return n, err


### PR DESCRIPTION
When response is JSON and it doesn't have Content-length header and Transfer-encoding header is not chunked, reader will use bufio where we miss the EOF and it never set the refreshed cache.

This fix will check the read length besides EOF err.