### PR TITLE
Fix stale gzip cache

### DIFF
--- a/httpcache.go
+++ b/httpcache.go
@@ -227,6 +227,11 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 		}
 		switch req.Method {
 		case "GET":
+			// Since the body is already uncompressed in the cache, we want to
+			// avoid the client trying to decompress it again
+			if resp.Header.Get("Content-Encoding") == "gzip" {
+				resp.Header.Del("Content-Encoding")
+			}
 			// Delay caching until EOF is reached.
 			resp.Body = &cachingReadCloser{
 				R: resp.Body,


### PR DESCRIPTION
In some cases when the original response used gzip, the cached response is already uncompressed, but since the Content-Encoding: gzip header still exists, the client may try to decompress the returned cached response (which already happened the first time it was saved in the cache).

Signed-off-by: Daniel Ortiz <dortiz@krakend.io>